### PR TITLE
Update to 0.1.6, update to documentation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Setting up a Reaction is simple. Follow these steps.
     - __Out Active__ React when this IO Output point changes from Not Active to Active
     - __Out Not Active__ React when this IO Output point changes from Active to Not Active
     - __GCode Command__ React when a specific GCode command is detected.
- 
+
+Note that when creating a reaction the format must follow a few rules. 
+- All key words are case sensitive.
+  - on, off, toggle, IO, GC, WT are all key words used when creating a reaction.
+  - When identifying an IO Point, it must be 2 characters in length. Example: IO point 1 is "01"
 
 ## UI Samples
 ![Settings](/assets/img/SettingsExample.png)

--- a/octoprint_SIOReaction/templates/sioreaction_settings.jinja2
+++ b/octoprint_SIOReaction/templates/sioreaction_settings.jinja2
@@ -18,14 +18,18 @@
                     <h4>Command formating:</h4>
                 </div>  
                 <div class="row-fluid">
-                    One command per new line in the command text box. Each command line must be prefixed with 
-                    2 characters that indicate what type of command it is.
+                    One command per new line in the command text box. 
+                    Each command line must be prefixed with 2 characters that indicate what type of command it is. 
+                    When using IO point numbers, you must use 2 digits. IO1 would be IO 01.
                 </div>
                 <div class="row-fluid">
                     <div class="span12"></div>
                     <div class="span12">"IO": Manupulate an IO point. This is only valid for configured output types.</div>
                     <div class="span12">
                         <div class="span4">Example (turns on IO point 11):</div><div class="span8 border"><strong>IO 11 on</strong></div>
+                    </div>    
+                    <div class="span12">
+                        <div class="span4">Example (toggles IO point 3):</div><div class="span8 border"><strong>IO 03 toggle</strong></div>
                     </div>    
                     <div class="span12">IO supported actions 'on','off', and 'toggle'</div>
                     <div class="span12"></div>

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ from setuptools import setup
 plugin_identifier = "SIOReaction"
 plugin_package = "octoprint_SIOReaction"
 plugin_name = "SIO Reaction"
-plugin_version = "0.1.5"
+plugin_version = "0.1.6"
 plugin_description = "Sub Plugin for SIO Control (v1+). Create reactions to changes in IO, GCode, and more."
 plugin_author = "jcassel"
 plugin_author_email = "jcassel@softwaresedge.com"
 plugin_url = "https://github.com/jcassel/OctoPrint-SIOReaction"
 plugin_license = "AGPLv3"
-# plugin_requires = []
+#plugin_requires = []
 plugin_requires = ["SIO-Control@https://github.com/jcassel/OctoPrint-Siocontrol/archive/main.zip"]
 plugin_additional_data = []
 plugin_additional_packages = []


### PR DESCRIPTION
Small update to 0.1.6, update to documentation. 
- Point out that IO# must be 2 characters in len in reactions. 
- No functional changes.