### PR TITLE
Adding minimal support for is_api_protected

### DIFF
--- a/octoprint_SIOReaction/__init__.py
+++ b/octoprint_SIOReaction/__init__.py
@@ -168,6 +168,12 @@ class SioreactionPlugin(
         if skipQueuing:
             return (None,)
 
+
+    def is_api_protected(self):
+        return True
+
+
+
     ##~~ AssetPlugin mixin
     def get_assets(self):
         # Define your plugin's asset files to automatically include in the

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 plugin_identifier = "SIOReaction"
 plugin_package = "octoprint_SIOReaction"
 plugin_name = "SIO Reaction"
-plugin_version = "0.1.6"
+plugin_version = "0.1.7"
 plugin_description = "Sub Plugin for SIO Control (v1+). Create reactions to changes in IO, GCode, and more."
 plugin_author = "jcassel"
 plugin_author_email = "jcassel@softwaresedge.com"


### PR DESCRIPTION
Added needed method to handle up coming check for 'is_api_protected" as noted in [OctoPrint release notes: 1.11.2](https://github.com/OctoPrint/OctoPrint/releases/tag/1.11.2)